### PR TITLE
A fix for ajax not being filtered out of the URL on search pages.

### DIFF
--- a/Plugin/CatalogSearch/Result.php
+++ b/Plugin/CatalogSearch/Result.php
@@ -86,6 +86,12 @@ class Result
         \Closure $method
     ){
         if($subject->getRequest()->getParam('ajax') == 1){
+
+            $subject->getRequest()->getQuery()->set('ajax', null);
+            $requestUri = $subject->getRequest()->getRequestUri();
+            $requestUri = preg_replace('/(\?|&)ajax=1/', '', $requestUri);
+            $subject->getRequest()->setRequestUri($requestUri);
+            
             $this->layerResolver->create(Resolver::CATALOG_LAYER_SEARCH);
             /* @var $query \Magento\Search\Model\Query */
             $query = $this->_queryFactory->get();


### PR DESCRIPTION
It works on the catalog pages but isn't implemented on search pages.